### PR TITLE
Add Kubernetes: les bases pour DevOps

### DIFF
--- a/courses/kubernetes_basics_intermediate_fr_eazytraining.yaml
+++ b/courses/kubernetes_basics_intermediate_fr_eazytraining.yaml
@@ -13,9 +13,6 @@ description: >
 prerequisites: Avoir de bonnes bases sur Docker.
 technologies:
   - kubernetes
-  - dockerlabs
-  - vagrant
-  - minikube
   - helm
 language: French
 deprecated: false

--- a/courses/kubernetes_basics_intermediate_fr_eazytraining.yaml
+++ b/courses/kubernetes_basics_intermediate_fr_eazytraining.yaml
@@ -1,0 +1,21 @@
+id: null
+name: "Kubernetes: les bases pour DevOps"
+url: https://eazytraining.fr/cours/kubernetes-les-bases-pour-devops/
+duration_hours: 10
+level: Intermediate
+objectives: Apprendre à déployer vos premières applications conteneurisées avec Kubernetes en utilisant des outils et concepts clés comme les pods, services, replicasets et Helm, pour une gestion efficace dans des environnements cloud-native.
+description: >
+  Kubernetes, k8s (pour k, 8 caractères, s) ou encore « kube », est une plateforme Open Source qui automatise l’exploitation des conteneurs Linux. 
+  Elle permet d’éliminer de nombreux processus manuels associés au déploiement et à la mise à l’échelle des applications conteneurisées. 
+  En d’autres termes, Kubernetes vous aide à gérer facilement et efficacement des clusters au sein desquels vous aurez rassemblé des groupes d’hôtes exécutant des conteneurs Linux. 
+  Ces clusters peuvent couvrir des hôtes situés dans des clouds publics, privés ou hybrides. 
+  C’est la raison pour laquelle Kubernetes est la plateforme idéale pour héberger les applications cloud-native qui requièrent une mise à l’échelle rapide, comme la diffusion de données en continu et en temps réel via Apache Kafka.
+prerequisites: Avoir de bonnes bases sur Docker.
+technologies:
+  - kubernetes
+  - dockerlabs
+  - vagrant
+  - minikube
+  - helm
+language: French
+deprecated: false


### PR DESCRIPTION
Ajout du fichier `kubernetes_basics_intermediate_fr_eazytraining.yaml` dans le dossier `courses/`. 
Ce cours couvre les bases de Kubernetes (pods, services, replicasets, Helm) pour un niveau intermédiaire.  

Le fichier respecte les conventions de nommage et la structure YAML définie dans le README.  

Merci
