### PR TITLE
Add Devenez aws certified associate architect et sysops.

### DIFF
--- a/courses/data_foundation_beginner_fr_eazytraining.yaml
+++ b/courses/data_foundation_beginner_fr_eazytraining.yaml
@@ -1,0 +1,15 @@
+id: null
+name: Data Foundation - débutez dans la data
+url: https://eazytraining.fr/cours/data-foundation-debutez-dans-la-data/
+duration_hours: 1
+level: Beginner
+objectives: Comprendre les principes de base pour réussir un projet d'analyse de données.
+description: >
+  Cette formation vous introduit au monde de la data. À travers une série de modules,
+  vous apprendrez les fondamentaux de l'analyse de données, l'importance de la Business Intelligence,
+  et les meilleures pratiques pour mener un projet réussi dans le domaine de la data.
+prerequisites: Pas de prérequis.
+technologies:
+  - 
+language: French
+deprecated: false

--- a/courses/devenez_aws_certified_associate_architect_et_sysops_beginner_fr_eazytraining.yaml
+++ b/courses/devenez_aws_certified_associate_architect_et_sysops_beginner_fr_eazytraining.yaml
@@ -1,0 +1,34 @@
+id: null
+name: Devenez aws certified associate architect et sysops. 
+url: https://eazytraining.fr/cours/devenez-aws-certified-associate-architect-et-sysops/
+duration_hours: 30
+level: Beginner
+objectives: 
+  Comprendre les fondamentaux du cloud computing et l'architecture AWS.
+  Savoir déployer des applications cloud en utilisant les services AWS.
+  Concevoir des architectures scalables et résilientes avec AWS.
+  Maîtriser la gestion des réseaux et des bases de données dans le cloud.
+  Automatiser les déploiements avec AWS CloudFormation et d'autres outils d'infrastructure en tant que code (IaC).
+  Gérer et optimiser les coûts cloud en utilisant les outils d'AWS Cost Management.
+  Implémenter des meilleures pratiques de sécurité sur AWS (IAM, KMS, WAF).
+  Préparer les participants à passer les certifications
+    AWS Cloud Practitioner,
+    Solutions Architect Associate.
+    AWS SysOps Administrator Associate
+description: >
+  Ce cours complet sur AWS Cloud Engineer vous guide pas à pas à travers l'univers du cloud computing avec AWS.
+  Vous apprendrez à concevoir, implémenter et maintenir des infrastructures cloud hautement disponibles,
+  sécurisées et évolutives, tout en maîtrisant les services AWS incontournables tels que EC2, S3, VPC, RDS,
+  Lambda, CloudFormation et bien d'autres..
+prerequisites: 
+  Une connaissance de base des réseaux et systèmes informatiques est recommandée.
+  Aucun prérequis spécifique en AWS n'est nécessaire, ce cours couvre tout de A à Z.
+technologies:
+  - EC2 
+  - S3
+  - Lambda 
+  - IAM
+  - RDS
+  - CloudFormation
+language: French
+deprecated: false

--- a/courses/devenez_testeur_logiciel_beginner_fr_eazytraining.yaml
+++ b/courses/devenez_testeur_logiciel_beginner_fr_eazytraining.yaml
@@ -1,0 +1,16 @@
+id: null
+name: Devenez testeur logiciel - Parcours complet de débutant à confirmé 
+url: https://eazytraining.fr/cours/devenez-testeur-logiciel-parcours-complet-de-debutant-a-confirme/
+duration_hours: 9
+level: Beginner
+objectives: Former des analystes qualité capables d'assurer la qualité des logiciels à toutes les étapes de leur cycle de vie.
+description: >
+  Cette formation aborde les bases du métier d'analyste qualité, la méthodologie des tests logiciels,
+  les outils nécessaires et les concepts avancés comme les tests mobiles et l'accessibilité.
+prerequisites: Pas de prérequis.
+technologies:
+  - Jira 
+  - Xray
+  - Postman
+language: French
+deprecated: false


### PR DESCRIPTION
Ajout du cours Devenez aws certified associate architect et sysops.
https://eazytraining.fr/cours/devenez-aws-certified-associate-architect-et-sysops/