### PR TITLE
Ajout du cous kubernetes-advanced

### DIFF
--- a/courses/kubernetes_advanced_fr_eazytraining.yaml
+++ b/courses/kubernetes_advanced_fr_eazytraining.yaml
@@ -1,0 +1,17 @@
+id: null
+name: Kubernetes Devenez Certified Kubernetes Security Specialist
+url:  https://eazytraining.fr/cours/kubernetes-devenez-certified-kubernetes-security-specialist/
+duration_hours: 15
+level: Expert
+objectives:  vous faire passer haut la main la certification kubernetes “Certified Kubernetes Security Specialist"
+description: >
+  Kubernetes, k8s (pour k, 8 caractères, s) ou encore « kube », est une plateforme Open Source qui automatise l’exploitation des conteneurs Linux. Elle permet d’éliminer de nombreux processus manuels associés au déploiement et à la mise à l’échelle des applications conteneurisées. En d’autres termes, Kubernetes vous aide à gérer facilement et efficacement des clusters au sein desquels vous aurez rassemblé des groupes d’hôtes exécutant des conteneurs Linux. Ces clusters peuvent couvrir des hôtes situés dans des clouds publics, privés ou hybrides. C’est la raison pour laquelle Kubernetes est la plateforme idéale pour héberger les applications cloud-native qui requièrent une mise à l’échelle rapide, comme la diffusion de données en continu et en temps réel via Apache Kafka.
+prerequisites: >
+ avoir de bonnes bases sur Docker (https://eazytraining.fr/cours/introduction-a-docker/)
+ avoir de bonnes bases sur kubernetes (https://eazytraining.fr/cours/kubernetes-les-bases-pour-devops/)
+ avoir de solides connaissances sur l’administration kubernetes (https://eazytraining.fr/cours/kubernetes-devenez-certified-kubernetes-administrator/)
+technologies:
+  - docker
+  - kubernetes
+language: French
+deprecated: false

--- a/courses/kubernetes_security_cks_advanced_fr_eazytraining.yaml
+++ b/courses/kubernetes_security_cks_advanced_fr_eazytraining.yaml
@@ -2,7 +2,7 @@ id: null
 name: Kubernetes Devenez Certified Kubernetes Security Specialist
 url:  https://eazytraining.fr/cours/kubernetes-devenez-certified-kubernetes-security-specialist/
 duration_hours: 15
-level: Expert
+level: Advanced
 objectives:  vous faire passer haut la main la certification kubernetes “Certified Kubernetes Security Specialist"
 description: >
   Kubernetes, k8s (pour k, 8 caractères, s) ou encore « kube », est une plateforme Open Source qui automatise l’exploitation des conteneurs Linux. Elle permet d’éliminer de nombreux processus manuels associés au déploiement et à la mise à l’échelle des applications conteneurisées. En d’autres termes, Kubernetes vous aide à gérer facilement et efficacement des clusters au sein desquels vous aurez rassemblé des groupes d’hôtes exécutant des conteneurs Linux. Ces clusters peuvent couvrir des hôtes situés dans des clouds publics, privés ou hybrides. C’est la raison pour laquelle Kubernetes est la plateforme idéale pour héberger les applications cloud-native qui requièrent une mise à l’échelle rapide, comme la diffusion de données en continu et en temps réel via Apache Kafka.


### PR DESCRIPTION
This pull request includes the addition of a new course to the `courses/kubernetes_advanced_fr_eazytraining.yaml` file. The course is designed to help participants become a Certified Kubernetes Security Specialist.

Key changes:

* Added a new course with the following details:
  * `name`: Kubernetes Devenez Certified Kubernetes Security Specialist
  * `url`: https://eazytraining.fr/cours/kubernetes-devenez-certified-kubernetes-security-specialist/
  * `duration_hours`: 15
  * `level`: Expert
  * `objectives`: vous faire passer haut la main la certification kubernetes “Certified Kubernetes Security Specialist"
  * `description`: Detailed description of Kubernetes and its benefits for managing Linux container clusters.
  * `prerequisites`: Links to prerequisite courses on Docker, Kubernetes basics, and Kubernetes administration.
  * `technologies`: Docker and Kubernetes
  * `language`: French
  * [`deprecated`](diffhunk://#diff-8db57854c468ea8ca414a05535ec0394a46b0055fbe052b61cde383d85d9beddR1-R17): false