### PR TITLE
Ajout du bootcamp Platform Engineer Kubernetes en français

### DIFF
--- a/bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml
+++ b/bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml
@@ -1,14 +1,18 @@
 id: null
 name: Platform Engineer Kubernetes Bootcamp
 target_role: Platform Engineer
-prerequisites: Connaissances en administration système et réseaux.
+prerequisites: Avoir les bases en DevOps (Jenkins, Docker, Kubernetes),Connaitre l’écosystème kubernetes (helm, operateur, argoCD), Avoir les bases en Cloud (AWS)
+, Etre familier des microservices (API, Endpoint, GRPC, stateful/stateless, scaling).
 url: https://eazytraining.fr/%C3%A9v%C3%A9nement/bootcamp-platform-engineer-kubernetes/
 modules:
-  - Module 1: Introduction à Kubernetes et à l'architecture des clusters
-  - Module 2: Déploiement et gestion des applications sur Kubernetes
-  - Module 3: Gestion des ressources Kubernetes et scaling
-  - Module 4: Réseautage et sécurité dans Kubernetes
-  - Module 5: Automatisation avec Helm
+  - Module 0: Présentation du métier de Platform Engineer et différence avec le DevOps Engineer
+  - Module 1: Rappel sur le DevOps et mise en place d’une pipeline complète sur Kubernetes (Service Pipeline)
+  - Module 2: GitOps multi-cluster avec ArgoCD (Environment pipeline)
+  - Module 3: Multi-Cloud infrastructure avec CrossPlane (AWS, GCP, AZURE …)
+  - Module 4: Création dynamique de cluster kubernetes avec vcluster + crossplane pour les développeurs
+  - Module 5: Délivrer des APIs standard pour middleware (cache, statestore) avec Dapr
+  - Module 6: Industrialiser la mise en production des applications avec knative
+  - Module 7: Mesurer les performances de votre “Platform Kubernetes” au service des développeurs avec les DORA metrics
 duration_weeks: 10
 language: French
 deprecated: false

--- a/bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml
+++ b/bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml
@@ -1,0 +1,14 @@
+id: null
+name: Platform Engineer Kubernetes Bootcamp
+target_role: Platform Engineer
+prerequisites: Connaissances en administration système et réseaux.
+url: https://eazytraining.fr/%C3%A9v%C3%A9nement/bootcamp-platform-engineer-kubernetes/
+modules:
+  - Module 1: Introduction à Kubernetes et à l'architecture des clusters
+  - Module 2: Déploiement et gestion des applications sur Kubernetes
+  - Module 3: Gestion des ressources Kubernetes et scaling
+  - Module 4: Réseautage et sécurité dans Kubernetes
+  - Module 5: Automatisation avec Helm
+duration_weeks: 10
+language: French
+deprecated: false

--- a/bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml
+++ b/bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml
@@ -1,8 +1,11 @@
 id: null
 name: Platform Engineer Kubernetes Bootcamp
 target_role: Platform Engineer
-prerequisites: Avoir les bases en DevOps (Jenkins, Docker, Kubernetes),Connaitre l’écosystème kubernetes (helm, operateur, argoCD), Avoir les bases en Cloud (AWS)
-, Etre familier des microservices (API, Endpoint, GRPC, stateful/stateless, scaling).
+prerequisites:
+  - Avoir les bases en DevOps (Jenkins, Docker, Kubernetes)
+  - Connaitre l’écosystème kubernetes (helm, operateur, argoCD)
+  - Avoir les bases en Cloud (AWS)
+  - Etre familier des microservices (API, Endpoint, GRPC, stateful/stateless, scaling).
 url: https://eazytraining.fr/%C3%A9v%C3%A9nement/bootcamp-platform-engineer-kubernetes/
 modules:
   - Module 0: Présentation du métier de Platform Engineer et différence avec le DevOps Engineer


### PR DESCRIPTION
## Description
Cette PR ajoute la description du bootcamp Platform Engineer Kubernetes en français.

## Modifications
- Ajout d'un fichier YAML : `bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml`.

## Validation
Le fichier YAML a été validé en local avec la commande suivante :
```bash
python scripts/validate_naming.py bootcamps/platform_engineer_kubernetes_bootcamp_fr.yaml

## Maintainer 
- Ing. NGUEYEP Modeste Dolumin
