### PR TITLE
Create devenez_site_reliabilty_advanced_fr_eazytraining.yaml

### DIFF
--- a/courses/devenez_site_reliabilty_advanced_fr_eazytraining.yaml
+++ b/courses/devenez_site_reliabilty_advanced_fr_eazytraining.yaml
@@ -1,0 +1,27 @@
+id: null
+name: Devenez Site Reliability Engineer
+url: https://eazytraining.fr/cours/devenez-site-reliability-engineer/
+duration_hours: 8
+level: Advanced
+objectives:  vous apprendre comment devenir un SRE dans un environnement de type micro-services orchestré par Kubernetes (qui est dorénavant un composant indispensable dans l’univers OpenSource et Cloud Native).
+description: >
+   Il est commun d’entendre que SRE est une implémentation concrète de la culture DevOps.
+    Bonne nouvelle, on parle bien de profil SRE puisque le terme Engineer en anglais fait référence à un ingénieur, donc une personne.
+    Commençons par discerner 5 piliers dans la culture DevOps:
+    - Faciliter la communication dans l’entreprise
+    - Accepter et banaliser les erreurs
+    - Appliquer des changements plus petits mais plus fréquents
+    - Automatiser les tâches les plus chronophages
+    - Relever tous les indicateurs qui pourraient être pertinents
+    Le SRE se présente comme une solution pour implémenter le DevOps dans les métiers d’exploitation (Backup, restauration, Upgrade, Scaling …).
+prerequisites: >
+   avoir de bonnes bases sur Docker (https://eazytraining.fr/cours/introduction-a-docker/)
+   avoir de bonnes bases sur kubernetes (https://eazytraining.fr/cours/kubernetes-les-bases-pour-devops/)
+technologies:
+  - docker
+  - kubernetes
+  - helm
+  - operator
+  - prometheus
+language: French
+deprecated: false


### PR DESCRIPTION
This pull request includes the addition of a new course to the `courses/devenez_site_reliabilty_advanced_fr_eazytraining.yaml` file. The course is titled "Devenez Site Reliability Engineer" and is provided by EazyTraining.

Details of the new course:

* Added course name: "Devenez Site Reliability Engineer"
* Included course URL: `https://eazytraining.fr/cours/devenez-site-reliability-engineer/`
* Specified course duration: 8 hours
* Set course level: Advanced
* Provided course objectives and description, emphasizing the implementation of DevOps culture through SRE practices
* Listed prerequisites, including foundational knowledge of Docker and Kubernetes
* Enumerated technologies covered in the course: Docker, Kubernetes, Helm, Operator, and Prometheus
* Indicated the course language: French
* Marked the course as not deprecated