### PR TITLE
Mrjojono add/course/platform engineer kubernetes intermediate

### DIFF
--- a/courses/gitops_avec_argocd_advanced_fr_eazytraining.yaml
+++ b/courses/gitops_avec_argocd_advanced_fr_eazytraining.yaml
@@ -1,0 +1,21 @@
+id: null
+name: GitOps avec ArgoCD  Continuous Delivery on Kubernetes
+url: https://eazytraining.fr/cours/gitops-avec-argocd-continuous-delivery-on-kubernetes/
+duration_hours: 4
+level: Advanced
+objectives: apprendre comment assurer du continuous deployment intelligent avec ArgoCD.
+description: >
+  Nous vivons dans le monde de l’IT une croissance exponentielle des micro-services, et pour les déployer à l’échelle on utilise des outils tels que Kubernetes. C’est pour cette raison que dans le cadre de cette formation nous apprendrons à faire du GitOps sur un cluster kubernetes. Et l’outil qui nous permettra de mettre cette culture en place est ArgoCD de ArgoProj.
+prerequisites:
+       Avoir de bonnes bases sur Docker (https://eazytraining.fr/cours/introduction-a-docker/)
+      Avoir de bonnes bases sur DevOps avec Jenkins Pipeline (https://eazytraining.fr/cours/jenkins-ci-cd-pour-devops/)
+      Avoir de bonnes bases sur Kubernetes (https://eazytraining.fr/cours/kubernetes-les-bases-pour-devops/)
+      Avoir les bases sur git (https://eazytraining.fr/cours/introduction-a-git/)
+technologies:
+  - argo-cd
+  - jenkins
+  - kubernetes
+  - git 
+  - docker
+language: French
+deprecated: false

--- a/courses/platform_engineer_kubernetes_intermediate_fr_eazytraining.yaml
+++ b/courses/platform_engineer_kubernetes_intermediate_fr_eazytraining.yaml
@@ -1,0 +1,18 @@
+id: null
+name: Platform Engineer Kubernetes
+url: https://eazytraining.fr/cours/platform-engineer-kubernetes/
+duration_hours: 4
+level: Intermediate
+objectives:  
+    Comprendre le rôle d’un Platform Engineer dans un environnement Kubernetes et DevOps.
+    Maîtriser l’architecture et le fonctionnement de Kubernetes pour orchestrer des conteneurs.
+    Apprendre à déployer des applications sur Kubernetes en utilisant des pratiques de CI/CD gitops.
+    Explorer les concepts de microservices et leur déploiement dans un cluster Kubernetes.
+    Gérer la sécurité, la mise à l’échelle et la résilience des applications dans Kubernetes.
+prerequisites: >
+   avoir de bonnes bases sur Docker (https://eazytraining.fr/cours/introduction-a-docker/)
+technologies:
+  - kubernetes
+  - helm
+language: French
+deprecated: false


### PR DESCRIPTION
This pull request adds two new course descriptions to the `courses` directory. The most important changes include the addition of course details for "Devenez Site Reliability Engineer" and "Platform Engineer Kubernetes."

New course descriptions:

* [`courses/devenez_site_reliabilty_advanced_fr_eazytraining.yaml`](diffhunk://#diff-7fc39b5f9027b80bab68646784540739fb6e3a239b1bee870a70c2eba7b0023cR1-R27): Added a detailed description for the advanced-level course "Devenez Site Reliability Engineer," including objectives, prerequisites, and technologies used.
* [`courses/platform_engineer_kubernetes_intermediate_fr_eazytraining.yaml`](diffhunk://#diff-719734cffadb2fb063c4f105243ad4f70e9df4c6f6ca9b1c135f594ec277e582R1-R18): Added a detailed description for the intermediate-level course "Platform Engineer Kubernetes," including objectives, prerequisites, and technologies used.
This pull request adds two new course entries to the `courses` directory. The courses focus on advanced and intermediate topics in site reliability engineering and platform engineering within Kubernetes environments.