### PR TITLE
Mrjojono add/course/platform engineer kubernetes intermediate 1

### DIFF
--- a/courses/devsecops_intermediate_fr_eazytraining.yaml
+++ b/courses/devsecops_intermediate_fr_eazytraining.yaml
@@ -14,7 +14,7 @@ prerequisites:
         avoir de bonnes bases sur Gitlab-ci  https://eazytraining.fr/cours/gitlab-ci-cd-pour-devops/
 technologies:
   - docker
-  - ontainers
+  - containerd
   - kubernetes
   - git 
   - gitlab

--- a/courses/gitops_avec_argocd_advanced_fr_eazytraining.yaml
+++ b/courses/gitops_avec_argocd_advanced_fr_eazytraining.yaml
@@ -1,0 +1,21 @@
+id: null
+name: GitOps avec ArgoCD  Continuous Delivery on Kubernetes
+url: https://eazytraining.fr/cours/gitops-avec-argocd-continuous-delivery-on-kubernetes/
+duration_hours: 4
+level: Advanced
+objectives: apprendre comment assurer du continuous deployment intelligent avec ArgoCD.
+description: >
+  Nous vivons dans le monde de l’IT une croissance exponentielle des micro-services, et pour les déployer à l’échelle on utilise des outils tels que Kubernetes. C’est pour cette raison que dans le cadre de cette formation nous apprendrons à faire du GitOps sur un cluster kubernetes. Et l’outil qui nous permettra de mettre cette culture en place est ArgoCD de ArgoProj.
+prerequisites:
+       Avoir de bonnes bases sur Docker (https://eazytraining.fr/cours/introduction-a-docker/)
+      Avoir de bonnes bases sur DevOps avec Jenkins Pipeline (https://eazytraining.fr/cours/jenkins-ci-cd-pour-devops/)
+      Avoir de bonnes bases sur Kubernetes (https://eazytraining.fr/cours/kubernetes-les-bases-pour-devops/)
+      Avoir les bases sur git (https://eazytraining.fr/cours/introduction-a-git/)
+technologies:
+  - argo-cd
+  - jenkins
+  - kubernetes
+  - git 
+  - docker
+language: French
+deprecated: false

--- a/courses/platform_engineer_kubernetes_intermediate_fr_eazytraining.yaml
+++ b/courses/platform_engineer_kubernetes_intermediate_fr_eazytraining.yaml
@@ -9,6 +9,8 @@ objectives:
     Apprendre à déployer des applications sur Kubernetes en utilisant des pratiques de CI/CD gitops.
     Explorer les concepts de microservices et leur déploiement dans un cluster Kubernetes.
     Gérer la sécurité, la mise à l’échelle et la résilience des applications dans Kubernetes.
+description: >
+  Ce cours est conçu pour les professionnels de l’informatique qui souhaitent se spécialiser en tant que Platform Engineer avec une expertise particulière en Kubernetes. Il couvre les compétences essentielles pour concevoir, déployer et gérer des plateformes cloud basées sur Kubernetes.
 prerequisites: >
    avoir de bonnes bases sur Docker (https://eazytraining.fr/cours/introduction-a-docker/)
 technologies:


### PR DESCRIPTION
This pull request adds two new course descriptions to the repository. The courses are focused on advanced site reliability engineering and intermediate platform engineering with Kubernetes, both in French.

New course additions:

* [`courses/devenez_site_reliabilty_advanced_fr_eazytraining.yaml`](diffhunk://#diff-7fc39b5f9027b80bab68646784540739fb6e3a239b1bee870a70c2eba7b0023cR1-R27): Added a new advanced-level course on becoming a Site Reliability Engineer, detailing its objectives, description, prerequisites, and technologies used.
* [`courses/platform_engineer_kubernetes_intermediate_fr_eazytraining.yaml`](diffhunk://#diff-719734cffadb2fb063c4f105243ad4f70e9df4c6f6ca9b1c135f594ec277e582R1-R20): Added a new intermediate-level course on Platform Engineering with Kubernetes, including its objectives, description, prerequisites, and technologies used.